### PR TITLE
[CEP-191] connection fail over

### DIFF
--- a/src/nats.erl
+++ b/src/nats.erl
@@ -120,15 +120,15 @@
                               port      => non_neg_integer() | undefined}.
 
 -type nats_server_opts() :: #{scheme     := binary(),
-                              preference   := 0..65535,
-                              host_order := 0..65535,
+                              preference := 0..65535,
+                              order      := 0..65535,
                               explicit   := boolean()}.
 
 -type nats_server() :: #{scheme     := binary(),
                          host       := nats_host(),
                          port       := non_neg_integer() | undefined,
-                         preference   := 0..65535,
-                         host_order := 0..65535,
+                         preference := 0..65535,
+                         host       := 0..65535,
                          explicit   := boolean()}.
 
 -type v0_opts() :: #{socket_opts    => socket_opts(),
@@ -141,6 +141,8 @@
                      auth_token     => binary(),
                      user           => binary(),
                      pass           => binary(),
+                     nkey_seed      => binary(),
+                     jwt            => binary(),
                      name           => binary(),
                      lang           => binary(),
                      version        => binary(),
@@ -208,6 +210,10 @@
                          send_timeout   := non_neg_integer(),
                          stop_on_error  := boolean(),
                          default_server_opts := nats_server_opts(),
+                         default_explicit_host_preference := 0..65535,
+                         default_explicit_host_order      := 0..65535,
+                         default_implicit_host_preference := 0..65535,
+                         default_implicit_host_order      := 0..65535,
                          servers        := [nats_server()],
                          _              => _
                         }.

--- a/src/nats_kv.erl
+++ b/src/nats_kv.erl
@@ -116,10 +116,19 @@
 %%% API
 %%%===================================================================
 
+-doc """
+Retrieves the configuration of a KeyValue store bucket.
+""".
+-spec get_bucket(Conn :: pid(), Bucket :: binary()) -> {ok, map()} | {error, term()}.
 get_bucket(Conn, Bucket)
   when is_binary(Bucket) ->
     get_bucket(Conn, Bucket, #{}).
 
+-doc """
+Retrieves the configuration of a KeyValue store bucket with additional options.
+""".
+-spec get_bucket(Conn :: pid(), Bucket :: binary(), Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 get_bucket(Conn, Bucket, Opts)
   when is_binary(Bucket) ->
     nats_stream:get(Conn, ?BUCKET_NAME(Bucket), Opts).
@@ -131,16 +140,26 @@ configuration.
 If a KeyValue store with the same name already exists and the
 configuration is different, ErrBucketExists will be returned.
 """.
+-spec create_bucket(Conn :: pid(), Bucket :: binary()) -> {ok, map()} | {error, term()}.
 create_bucket(Conn, Bucket)
   when is_binary(Bucket) ->
     create_bucket(Conn, #{bucket => Bucket}, #{}).
 
--spec create_bucket(Conn :: pid(), Config :: config(), Opts :: map()) -> term().
+-doc """
+Creates a KeyValue store bucket with the specified configuration and options.
+""".
+-spec create_bucket(Conn :: pid(), Config :: config(), Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 create_bucket(Conn, #{bucket := Bucket} = Config, Opts)
   when is_binary(Bucket) ->
     StreamCfg = prepare_key_value_config(Config),
     nats_stream:create(Conn, StreamCfg, Opts).
 
+-doc """
+Creates a KeyValue store bucket with the specified bucket name, configuration, and options.
+""".
+-spec create_bucket(Conn :: pid(), Bucket :: binary(), Config :: map(), Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 create_bucket(Conn, Bucket, Config, Opts)
   when is_binary(Bucket), is_map(Config), is_map(Opts) ->
     create_bucket(Conn, Config#{bucket => Bucket}, Opts).
@@ -152,16 +171,25 @@ configuration.
 If a KeyValue store with the given name does not exist, ErrBucketNotFound
 will be returned.
 """.
+-spec update_bucket(Conn :: pid(), Bucket :: binary()) -> {ok, map()} | {error, term()}.
 update_bucket(Conn, Bucket)
   when is_binary(Bucket) ->
     update_bucket(Conn, #{bucket => Bucket}, #{}).
 
+-doc """
+Updates an existing KeyValue store bucket with the specified configuration and options.
+""".
 -spec update_bucket(Conn :: pid(), Config :: config(), Opts :: map()) -> term().
 update_bucket(Conn, #{bucket := Bucket} = Config, Opts)
   when is_binary(Bucket) ->
     StreamCfg = prepare_key_value_config(Config),
     nats_stream:update(Conn, StreamCfg, Opts).
 
+-doc """
+Updates an existing KeyValue store bucket with the specified bucket name, configuration, and options.
+""".
+-spec update_bucket(Conn :: pid(), Bucket :: binary(), Config :: map(), Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 update_bucket(Conn, Bucket, Config, Opts)
   when is_binary(Bucket), is_map(Config), is_map(Opts) ->
     update_bucket(Conn, Config#{bucket => Bucket}, Opts).
@@ -172,11 +200,16 @@ DeleteKeyValue will delete this KeyValue store.
 If the KeyValue store with given name does not exist,
 ErrBucketNotFound will be returned.
 """.
+-spec delete_bucket(Conn :: pid(), Bucket :: binary()) -> {ok, map()} | {error, term()}.
 delete_bucket(Conn, Bucket)
   when is_binary(Bucket) ->
     delete_bucket(Conn, Bucket, #{}).
 
-
+-doc """
+Deletes a KeyValue store bucket with the specified options.
+""".
+-spec delete_bucket(Conn :: pid(), Bucket :: binary(), Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 delete_bucket(Conn, Bucket, Opts)
   when is_binary(Bucket), is_map(Opts) ->
     nats_stream:delete(Conn, ?BUCKET_NAME(Bucket), Opts).
@@ -199,10 +232,15 @@ data, not the entry value.
 - ResumeFromRevision instructs the key watcher to resume from a
 specific revision number.
 """.
+-spec watch(Conn :: pid(), Bucket :: binary(), Keys :: binary() | [binary()], WatchOpts :: map(), Opts :: map()) -> {ok, pid()} | {error, term()}.
 watch(Conn, Bucket, Keys, WatchOpts, Opts)
   when is_binary(Bucket), is_map(WatchOpts), is_map(Opts) ->
     watch(Conn, Bucket, Keys, WatchOpts, Opts, [{spawn_opt, [link]}]).
 
+-doc """
+Watch for any updates to keys with additional start options for the watcher process.
+""".
+-spec watch(Conn :: pid(), Bucket :: binary(), Keys :: binary() | [binary()], WatchOpts :: map(), Opts :: map(), StartOpts :: [term()]) -> {ok, pid()} | {error, term()}.
 watch(Conn, Bucket, Keys, WatchOpts, Opts, StartOpts)
   when is_binary(Bucket), is_map(WatchOpts), is_map(Opts) ->
     nats_kv_watch:start(Conn, Bucket, Keys, WatchOpts, Opts, StartOpts).
@@ -210,10 +248,15 @@ watch(Conn, Bucket, Keys, WatchOpts, Opts, StartOpts)
 -doc """
 WatchAll will invoke the callback for all updates.
 """.
+-spec watch_all(Conn :: pid(), Bucket :: binary(), WatchOpts :: map(), Opts :: map()) -> {ok, pid()} | {error, term()}.
 watch_all(Conn, Bucket, WatchOpts, Opts)
   when is_binary(Bucket), is_map(WatchOpts), is_map(Opts) ->
     watch(Conn, Bucket, ~">", WatchOpts, Opts, [{spawn_opt, [link]}]).
 
+-doc """
+Watch for all updates with additional start options for the watcher process.
+""".
+-spec watch_all(Conn :: pid(), Bucket :: binary(), WatchOpts :: map(), Opts :: map(), StartOpts :: [term()]) -> {ok, pid()} | {error, term()}.
 watch_all(Conn, Bucket, WatchOpts, Opts, StartOpts)
   when is_binary(Bucket), is_map(WatchOpts), is_map(Opts) ->
     nats_kv_watch:start(Conn, Bucket, ~">", WatchOpts, Opts, StartOpts).
@@ -222,9 +265,14 @@ watch_all(Conn, Bucket, WatchOpts, Opts, StartOpts)
 SekectKeys will return KeyLister, allowing to retrieve selected keys from
 the key value store in a streaming fashion (on a channel).
 """.
+-spec select_keys(Conn :: pid(), Bucket :: binary(), Keys :: binary() | [binary()], WatchOpts :: map()) -> {ok, list()} | {error, term()}.
 select_keys(Conn, Bucket, Keys, WatchOpts) ->
     select_keys(Conn, Bucket, Keys, WatchOpts, #{}).
 
+-doc """
+Selects keys from the key value store with additional options.
+""".
+-spec select_keys(Conn :: pid(), Bucket :: binary(), Keys :: binary() | [binary()], WatchOpts :: map(), Opts :: map()) -> {ok, list()} | {error, term()}.
 select_keys(Conn, Bucket, Keys, WatchOpts0, Opts) ->
     WatchOpts = WatchOpts0#{ignore_deletes => true,
                             cb => fun select_keys_watch_cb/3},
@@ -255,9 +303,14 @@ select_keys_loop(Pid, Acc) ->
 ListKeys will return KeyLister, allowing to retrieve all keys from
 the key value store in a streaming fashion (on a channel).
 """.
+-spec list_keys(Conn :: pid(), Bucket :: binary(), WatchOpts :: map()) -> {ok, list()} | {error, term()}.
 list_keys(Conn, Bucket, WatchOpts) ->
     list_keys(Conn, Bucket, WatchOpts, #{}).
 
+-doc """
+Lists all keys from the key value store with additional options.
+""".
+-spec list_keys(Conn :: pid(), Bucket :: binary(), WatchOpts :: map(), Opts :: map()) -> {ok, list()} | {error, term()}.
 list_keys(Conn, Bucket, WatchOpts, Opts) ->
     select_keys(Conn, Bucket, ~">", WatchOpts, Opts).
 
@@ -265,10 +318,19 @@ list_keys(Conn, Bucket, WatchOpts, Opts) ->
 Get returns the latest value for the key. If the key does not exist,
 ErrKeyNotFound will be returned.
 """.
+-spec get(Conn :: pid(), Bucket :: binary(), Key :: binary()) -> {ok, binary()} | {deleted, map()} | {error, term()}.
 get(Conn, Bucket, Key)
   when is_binary(Bucket), is_binary(Key) ->
     get(Conn, Bucket, Key, last, #{}).
 
+-doc """
+Gets a specific revision of a key by sequence number or
+the latest value for a key with additional options.
+""".
+-spec get(Conn :: pid(), Bucket :: binary(), Key :: binary(), SeqNo :: integer() | last) ->
+          {ok, binary()} | {deleted, map()} | {error, term()};
+         (Conn :: pid(), Bucket :: binary(), Key :: binary(), Opts :: map()) ->
+          {ok, binary()} | {deleted, map()} | {error, term()}.
 get(Conn, Bucket, Key, SeqNo)
   when SeqNo =:= last; is_integer(SeqNo) ->
     get(Conn, Bucket, Key, SeqNo, #{});
@@ -276,6 +338,13 @@ get(Conn, Bucket, Key, Opts)
   when is_binary(Bucket), is_binary(Key), is_map(Opts) ->
     get(Conn, Bucket, Key, last, Opts).
 
+-doc """
+Gets a specific revision of a key by sequence number with additional options.
+""".
+-spec get(Conn :: pid(), Bucket :: binary(), Key :: binary(), SeqNo :: integer() | 'last', Opts :: map()) ->
+          {'ok', map()} |
+          {'deleted', #{'message':=#{'hdrs':=maybe_improper_list(), _=>_}, _=>_}} |
+          {'error', term()}.
 get(Conn, Bucket, Key, SeqNo, Opts) ->
     case get_msg(Conn, Bucket, Key, SeqNo, Opts) of
         {ok, #{message := #{hdrs := Headers}} = Response} ->
@@ -289,6 +358,12 @@ get(Conn, Bucket, Key, SeqNo, Opts) ->
             Response
     end.
 
+-doc """
+Retrieves the raw message for a key at a specific sequence number or the last message.
+This function is typically used internally by `get/5`.
+""".
+-spec get_msg(Conn :: pid(), Bucket :: binary(), Key :: binary(), SeqNo :: integer() | last, Opts :: map()) ->
+          {ok, map()} | {error, term()}.
 get_msg(Conn, Bucket, Key, last, Opts) ->
     get_last_msg_for_subject(Conn, Bucket, Key, Opts);
 get_msg(Conn, Bucket, Key, SeqNo, Opts)
@@ -334,6 +409,7 @@ be updated.
 A key has to consist of alphanumeric characters, dashes, underscores,
 equal signs, and dots.
 """.
+-spec put(Conn :: pid(), Bucket :: binary(), Key :: binary(), Value :: binary()) -> {ok, map()} | {error, term()}.
 put(Conn, Bucket, Key, Value)
   when is_binary(Bucket), is_binary(Key) ->
     case nats:request(Conn, ?SUBJECT_NAME(Bucket, Key), Value, #{}) of
@@ -350,9 +426,14 @@ already exists, ErrKeyExists will be returned.
 A key has to consist of alphanumeric characters, dashes, underscores,
 equal signs, and dots.
 """.
+-spec create(Conn :: pid(), Bucket :: binary(), Key :: binary(), Value :: binary()) -> {ok, map()} | {error, term()}.
 create(Conn, Bucket, Key, Value) ->
     create(Conn, Bucket, Key, Value, #{}).
 
+-doc """
+Creates a key/value pair with additional options.
+""".
+-spec create(Conn :: pid(), Bucket :: binary(), Key :: binary(), Value :: binary(), Opts :: map()) -> {ok, map()} | {error, term()}.
 create(Conn, Bucket, Key, Value, Opts) ->
     create_do(Conn, Bucket, Key, Value, maps:merge(#{retry => true}, Opts)).
 
@@ -385,6 +466,8 @@ create_do(Conn, Bucket, Key, Value, #{retry := Retry} = Opts)
 Update will update the value if the latest revision matches.
 If the provided revision is not the latest, Update will return an error.
 """.
+-spec update(Conn :: pid(), Bucket :: binary(), Key :: binary(), Value :: binary(), SeqNo :: integer()) ->
+          {ok, map()} | {error, term()}.
 update(Conn, Bucket, Key, Value, SeqNo)
   when is_binary(Bucket), is_binary(Key) ->
     Header =
@@ -392,8 +475,8 @@ update(Conn, Bucket, Key, Value, SeqNo)
     case nats:request(Conn, ?SUBJECT_NAME(Bucket, Key), Value, #{header => Header}) of
         {ok, Response} ->
             unmarshal_response(Response);
-        Other ->
-            Other
+        {error, _} = Error ->
+            Error
     end.
 
 -doc """
@@ -405,9 +488,14 @@ will not remove any previous revisions from the underlying stream.
 `LastRevision` option can be specified to only perform delete if the
 latest revision the provided one.
 """.
+-spec delete(Conn :: pid(), Bucket :: binary(), Key :: binary()) -> {ok, map()} | {error, term()}.
 delete(Conn, Bucket, Key) ->
     delete(Conn, Bucket, Key, #{}).
 
+-doc """
+Deletes a key with additional options.
+""".
+-spec delete(Conn :: pid(), Bucket :: binary(), Key :: binary(), Opts :: map()) -> {ok, map()} | {error, term()}.
 delete(Conn, Bucket, Key, Opts)
   when is_binary(Bucket), is_binary(Key), is_map(Opts) ->
     Headers0 =
@@ -428,8 +516,8 @@ delete(Conn, Bucket, Key, Opts)
     case nats:request(Conn, ?SUBJECT_NAME(Bucket, Key), <<>>, #{header => Header}) of
         {ok, Response} ->
             unmarshal_response(Response);
-        Other ->
-            Other
+        {error, _} = Error ->
+            Error
     end.
 
 -doc """
@@ -441,9 +529,14 @@ previous revisions from the underlying streams.
 `LastRevision` option can be specified to only perform purge if the
 latest revision the provided one.
 """.
+-spec purge(Conn :: pid(), Bucket :: binary(), Key :: binary()) -> {ok, map()} | {error, term()}.
 purge(Conn, Bucket, Key) ->
     purge(Conn, Bucket, Key, #{}).
 
+-doc """
+Purges a key with additional options.
+""".
+-spec purge(Conn :: pid(), Bucket :: binary(), Key :: binary(), Opts :: map()) -> {ok, map()} | {error, term()}.
 purge(Conn, Bucket, Key, Opts) ->
     delete(Conn, Bucket, Key, Opts#{purge => true}).
 

--- a/src/nats_kv.erl
+++ b/src/nats_kv.erl
@@ -301,8 +301,8 @@ get_last_msg_for_subject(Conn, Bucket, Key, #{allow_direct := true} = Opts) ->
     case nats:request(Conn, Topic, <<>>, #{}) of
         {ok, Response} ->
             direct_msg_response(Response);
-        Other ->
-            Other
+        {error, _} = Error ->
+            Error
     end;
 get_last_msg_for_subject(Conn, Bucket, Key, Opts) ->
     get_msg(Conn, Bucket, #{last_by_subj => Key}, Opts).
@@ -313,8 +313,8 @@ get_msg(Conn, Bucket, Req, #{allow_direct := true} = Opts) ->
     case nats:request(Conn, Topic, JSON, Opts) of
         {ok, Response} ->
             direct_msg_response(Response);
-        Other ->
-            Other
+        {error, _} = Error ->
+            Error
     end;
 get_msg(Conn, Bucket, Req, Opts) ->
     Name = ?BUCKET_NAME(Bucket),
@@ -513,9 +513,6 @@ unmarshal_response({Response, _Opts}) ->
         C:E:St ->
             {error, {C, E, St}}
     end.
-
-direct_msg_response({#{error := Error}, _}) ->
-    {error, Error};
 
 direct_msg_response({_Content,
                      #{header := <<"NATS/1.0 ", Code:3/bytes, " ", Rest/binary>>}}) ->

--- a/src/nats_kv_watch.erl
+++ b/src/nats_kv_watch.erl
@@ -30,6 +30,7 @@
 %% OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -module(nats_kv_watch).
+-moduledoc false.
 
 -behaviour(gen_statem).
 

--- a/src/nats_kv_watch.erl
+++ b/src/nats_kv_watch.erl
@@ -173,8 +173,8 @@ handle_event(info, {Conn, Sid, Msg0}, State, #data{conn = Conn, sid = Sid} = Dat
 terminate(_Reason, _State,
           #data{conn = Conn,
                 watch = #{config := #{deliver_subject := DeliverSubject}} = Watch}) ->
-    nats:unsub(Conn, DeliverSubject),
-    nats_consumer:delete(Conn, Watch),
+    _ = nats:unsub(Conn, DeliverSubject),
+    _ = nats_consumer:delete(Conn, Watch),
     ok.
 
 code_change(_OldVsn, State, Data, _Extra) ->
@@ -183,7 +183,7 @@ code_change(_OldVsn, State, Data, _Extra) ->
 handle_message({msg, _, _, #{status := 100, reply_to := ReplyTo}} = _Msg,
                _State, #data{conn = Conn}) ->
     %% FlowControl Request
-    nats:pub(Conn, ReplyTo),
+    _ = nats:pub(Conn, ReplyTo),
     keep_state_and_data;
 handle_message({msg, _, <<>>,
                 #{status := 100, description := <<"Idle", _/binary>>,

--- a/src/nats_nkey.erl
+++ b/src/nats_nkey.erl
@@ -15,6 +15,7 @@
 %% module contains only the minimum functions required for nkeys
 
 -module(nats_nkey).
+-moduledoc false.
 
 -export([decode_base32/1, encode_base32/1]).
 -export([from_seed/1, public/1, sign/2]).

--- a/src/nats_pull_consumer.erl
+++ b/src/nats_pull_consumer.erl
@@ -94,7 +94,7 @@ init([Module, Conn, Stream, Name, NatsOpts]) ->
         Inbox = <<"_INBOX.", (nats:rnd_topic_id())/binary, $., (nats:rnd_topic_id())/binary>>,
         {ok, Sid} ?= nats:sub(Conn, Inbox),
 
-        nats_consumer:msg_next(Conn, Stream, Name, Inbox, #{batch => BatchSize}, NatsOpts),
+        ok ?= nats_consumer:msg_next(Conn, Stream, Name, Inbox, #{batch => BatchSize}, NatsOpts),
 
         State = #state{
                    module = Module,
@@ -135,8 +135,8 @@ handle_info({Conn, Sid, {msg, Subject, Message, Opts}},
         case State of
             #state{stream = Stream, name = Name, inbox = Inbox, nats_opts = NatsOpts,
                    batch_size = BatchSize, batch_outstanding = 1} ->
-                nats_consumer:msg_next(
-                  Conn, Stream, Name, Inbox, #{batch => BatchSize}, NatsOpts),
+                ok = nats_consumer:msg_next(
+                       Conn, Stream, Name, Inbox, #{batch => BatchSize}, NatsOpts),
                 BatchSize;
             #state{batch_outstanding = Outstanding} ->
                 Outstanding

--- a/test/nats_SUITE.erl
+++ b/test/nats_SUITE.erl
@@ -289,7 +289,7 @@ multi_server_reconnect_server(Owner) ->
     {ok, S1} = nats_fake_server:start_link(),
     {ok, S2} = nats_fake_server:start_link(),
 
-    Server = #{scheme => ~"nats", host => ~"localhost"},
+    Server = #{scheme => ~"nats", host => ~"localhost", family => inet},
     Server1 = Server#{port => nats_fake_server:port(S1)},
     Server2 = Server#{port => nats_fake_server:port(S2)},
     Owner ! {ready, self(), [Server1, Server2]},

--- a/test/nats_SUITE.erl
+++ b/test/nats_SUITE.erl
@@ -43,7 +43,8 @@ all() ->
      unsub_verbose_ok,
      request_no_responders,
      micro_ok,
-     micro_verbose_ok].
+     micro_verbose_ok,
+     multi_server_reconnect].
 
 init_per_suite(Config) ->
     Level = ct:get_config(log_level, info),
@@ -74,13 +75,13 @@ connect_ok(_) ->
 
 connect_fail_no_host(_) ->
     %% connect returns a new connection process,
-    %% If the connection fails (host not found),
-    %% a {Connection, {error, nxdomain}} message is sent to the owner
+    %% If if there are no valid servers left,
+    %% a {Connection, {error, no_more_candidates}} message is sent to the owner
 
     {ok, _Host, Port} = nats_addr(),
     {ok, C} = nats:connect(<<"doesnt-exist.google.com">>, Port),
     receive
-        {C, {error, nxdomain}} -> ok
+        {C, {error, no_more_candidates}} -> ok
     after 1000 ->
             throw(error_on_fail_not_sent)
     end.
@@ -275,6 +276,275 @@ micro_verbose_ok(_) ->
     after 1000 ->
             ok
     end.
+
+multi_server_reconnect_server(Owner) ->
+    nats_msg:init(),
+
+    {ok, S1} = nats_fake_server:start_link(),
+    {ok, S2} = nats_fake_server:start_link(),
+
+    Server = #{scheme => ~"nats", host => ~"localhost"},
+    Server1 = Server#{port => nats_fake_server:port(S1)},
+    Server2 = Server#{port => nats_fake_server:port(S2)},
+    Owner ! {ready, self(), [Server1, Server2]},
+    multi_server_reconnect_server_loop(Owner, undefined).
+
+multi_server_reconnect_server_loop(Owner, Connected) ->
+    receive
+        {closed, Pid, Socket} when Connected =:= {Pid, Socket} ->
+            Owner ! {closed, self(), Pid, Socket},
+            multi_server_reconnect_server_loop(Owner, undefined);
+        {accepted, Pid, Socket} when Connected =:= undefined ->
+            Info =
+                #{server_id => ~"Server-Id",
+                  server_name => ~"Server-Name",
+                  version => ~"2.11.0",
+                  proto => 1,
+                  go => ~"go1.24.1",
+                  host => ~"0.0.0.0",
+                  port => 4222,
+                  headers => true,
+                  max_payload => 1048576,
+                  jetstream => true
+                 },
+            Msg = iolist_to_binary([~"INFO ", json:encode(Info), ~"\r\n"]),
+            nats_fake_server:send(Pid, Socket, Msg),
+            multi_server_reconnect_server_loop(Owner, {Pid, Socket});
+        {recv, Pid, Socket, Data} when Connected =:= {Pid, Socket} ->
+            try nats_msg:decode_all(Data) of
+                {Msgs, <<>>} ->
+                    lists:foreach(
+                      fun({connect, _ClientInfo}) ->
+                              Owner ! {connected, self(), Pid, Socket};
+                         ({sub, Sub}) ->
+                              ct:pal("NATS-SUB: ~0p", [Sub]),
+                              Owner ! {sub, self(), Pid, Socket, Sub};
+                         ({unsub, Unsub}) ->
+                              ct:pal("NATS-UNSUB: ~0p", [Unsub]),
+                              Owner ! {unsub, self(), Pid, Socket, Unsub};
+                         (Msg) ->
+                              ct:pal("NATS-Server Msg: ~0p", [Msg])
+                      end, Msgs)
+            catch
+                C:E:St ->
+                    ct:pal("NATS decode error: ~p:~p~nStack: ~p~nMsg: ~0p", [C, E, St, Data])
+            end,
+            multi_server_reconnect_server_loop(Owner, Connected);
+        Msg ->
+            ct:pal("got unexpected msg: ~0p", [Msg]),
+            error(exit)
+    end.
+
+-define(assertNoMessage(X_Wait),
+        begin
+            ((fun() ->
+                      receive X_M ->
+                              ct:pal("got unexpected message: ~0p", [X_M]),
+                              throw(unexpected_message)
+                      after X_Wait -> ok
+                      end
+              end)())
+        end).
+
+multi_server_reconnect_collect_subs(0, _, Acc) ->
+    lists:reverse(Acc);
+multi_server_reconnect_collect_subs(Cnt, SPid, Acc) ->
+    receive
+        {Tag, SPid, Pid, Socket, Msg}
+          when Tag =:= sub; Tag =:= unsub ->
+            multi_server_reconnect_collect_subs(
+              Cnt - 1, SPid, [{Tag, Msg, {Pid, Socket}}|Acc])
+    after 10_000 -> throw(sub_msg_not_received)
+    end.
+
+multi_server_reconnect(_) ->
+    %% the test sequence can be slightly hard to follow as it gets messages from
+    %% nats client and from the test server. However, interleaving them in a single
+    %% sequential flow is much simpler for the test than having to synchronize
+    %% multiple processes.
+
+    SPid = proc_lib:spawn_link(?MODULE, multi_server_reconnect_server, [self()]),
+
+    Servers =
+        receive {ready, SPid, S} -> S
+        after 1000 -> throw(servers_not_ready)
+        end,
+
+    {ok, C} = nats:connect(#{servers => Servers, verbose => false}),
+    receive {C, ready} -> ok
+    after 1000 -> throw(ready_msg_not_sent)
+    end,
+
+    %% connect message from our test server loop
+    {connected, _, Srv1Pid, Srv1Socket} =
+        receive {connected, SPid, _, _} = Msg1 -> Msg1
+        after 1000 -> throw(connected_msg_not_sent)
+        end,
+
+    %% there should be no pending messages
+    ?assertNoMessage(1000),
+
+    %% send a sequence, of SUB foo.*, UNSUB Sid MaxMsgs, SUB zzz.*
+    {ok, NatsSid1} = nats:sub(C, ~"foo.*"),
+    ok = nats:unsub(C, NatsSid1, #{max_messages => 1000}),
+    {ok, _NatsSid2} = nats:sub(C, ~"zzz.*"),
+
+    %% activate the inbox subscription, cheat and call the server directly
+    %% we could instead do a nats:request(), but that would make it more complex
+    {ok, _Inbox} = gen_statem:call(C, get_inbox_topic),
+
+    %% collect the sub, unsub, sub from the fake server
+    Subs1 = multi_server_reconnect_collect_subs(4, SPid, []),
+    ?assertMatch(
+       [{sub, {~"foo.*", _, _}, {Srv1Pid, Srv1Socket}},
+        {unsub, {_, 1000}, {Srv1Pid, Srv1Socket}},
+        {sub, {<<"zzz.*">>, _ , _}, {Srv1Pid, Srv1Socket}},
+        {sub, {<<"_INBOX.", _/binary>>, _, _}, {Srv1Pid, Srv1Socket}}
+       ],
+       Subs1),
+    {_, {_, _, BinSid}, _} = hd(Subs1),
+
+    %% set a msg ...
+    SendMsg1 = nats_msg:encode({msg, {~"foo.bar", BinSid, undefined, ~"Hello"}}),
+    ct:pal("SendMsg1: ~0p", [SendMsg1]),
+    nats_fake_server:send(Srv1Pid, Srv1Socket, SendMsg1),
+
+    %% ... and check that the subscription works
+    receive {C, NatsSid1, {msg, _, _, _}} -> ok
+    after 1000 -> throw(sub_msg_not_received)
+    end,
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    %% kill the socket on the test server
+    nats_fake_server:close(Srv1Pid, Srv1Socket),
+
+    %% close message from our test server loop
+    {closed, _, Srv1Pid, Srv1Socket} =
+        receive {closed, SPid, _, _} = Msg2 -> Msg2
+        after 1000 -> throw(close_msg_not_sent)
+        end,
+
+    %% closed
+    receive {C, closed} -> ok
+    after 1000 -> throw(closed_msg_not_sent)
+    end,
+
+    %% wait for the reconnect
+    receive {C, ready} -> ok
+    after 1000 -> throw(ready_msg_not_sent)
+    end,
+
+    %% reconnect message from our test server loop
+    {connected, _, Srv2Pid, Srv2Socket} =
+        receive {connected, SPid, _, _} = Msg3 -> Msg3
+        after 1000 -> throw(connected_msg_not_sent)
+        end,
+
+    %% it should have connected to the other test server socket
+    ?assertNotEqual(Srv1Pid, Srv2Pid),
+
+    %% collect the sub, unsub, sub restoration messages from the fake server
+    Subs2 = multi_server_reconnect_collect_subs(4, SPid, []),
+    %% ct:pal("Srv2Pid: ~p~nSrv2Socket: ~p", [Srv2Pid, Srv2Socket]),
+    ?assertMatch(
+       [{sub, {~"foo.*", _, _}, {Srv2Pid, Srv2Socket}},
+        {unsub, {_, 999}, {Srv2Pid, Srv2Socket}},
+        {sub, {<<"zzz.*">>, _ , _}, {Srv2Pid, Srv2Socket}},
+        {sub, {<<"_INBOX.", _/binary>>, _, _}, {Srv2Pid, Srv2Socket}}
+       ],
+       Subs2),
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    %% activate a microserver with its subscriptions
+    Svc = #{name => ~"FOOBAR",
+            version => ~"2.0.0",
+            module => ?MODULE,
+            state => [],
+            endpoints =>
+                [#{name => ~"echo", function => echo}]},
+    ok = nats_service:serve(C, Svc),
+
+    %% should result in 10 additional subscriptions
+    multi_server_reconnect_collect_subs(10, SPid, []),
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    %% subscription should still work
+    nats_fake_server:send(Srv2Pid, Srv2Socket, SendMsg1),
+    receive {C, NatsSid1, {msg, _, _, _}} -> ok
+    after 1000 -> throw(sub_msg_not_received)
+    end,
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    %% kill the socket on the test server
+    nats_fake_server:close(Srv2Pid, Srv2Socket),
+
+    %% close message from our test server loop
+    {closed, _, Srv2Pid, Srv2Socket} =
+        receive {closed, SPid, _, _} = Msg4 -> Msg4
+        after 1000 -> throw(close_msg_not_sent)
+        end,
+
+    %% closed
+    receive {C, closed} -> ok
+    after 1000 -> throw(closed_msg_not_sent)
+    end,
+
+    %% wait for the reconnect
+    receive {C, ready} -> ok
+    after 1000 -> throw(ready_msg_not_sent)
+    end,
+
+    %% reconnect message from our test server loop
+    {connected, _, Srv3Pid, Srv3Socket} =
+        receive {connected, SPid, _, _} = Msg5 -> Msg5
+        after 1000 -> throw(connected_msg_not_sent)
+        end,
+
+    %% it should now be back on the first test server socket
+    ?assertEqual(Srv1Pid, Srv3Pid),
+
+    %% collect the sub, unsub, sub restoration messages from the fake server
+    Subs3 = multi_server_reconnect_collect_subs(14, SPid, []),
+    %% ct:pal("Srv3Pid: ~p~nSrv3Socket: ~p", [Srv3Pid, Srv3Socket]),
+    ?assertMatch(
+       [{sub, {~"foo.*", _, _}, {Srv3Pid, Srv3Socket}},
+        {unsub, {_, 998}, {Srv3Pid, Srv3Socket}},
+        {sub, {<<"zzz.*">>, _ , _}, {Srv3Pid, Srv3Socket}},
+        {sub, {<<"_INBOX.", _/binary>>, _, _}, {Srv3Pid, Srv3Socket}}
+       | _
+       ],
+       Subs3),
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    %% disconnect should be clean
+    ok = nats:disconnect(C),
+    {error, not_found} = nats:is_ready(C),
+
+    %% closed
+    receive {C, closed} -> ok
+    after 1000 -> throw(closed_msg_not_sent)
+    end,
+
+    %% close message from our test server loop
+    {closed, _, Srv3Pid, Srv3Socket} =
+        receive {closed, SPid, _, _} = Msg6 -> Msg6
+        after 1000 -> throw(close_msg_not_sent)
+        end,
+
+    %% there should be no more pending messages
+    ?assertNoMessage(1000),
+
+    ok.
 
 send_tcp_msg(BinHost, Port, BinMsg) ->
     Host = binary_to_list(BinHost),

--- a/test/nats_SUITE.erl
+++ b/test/nats_SUITE.erl
@@ -71,7 +71,13 @@ connect_ok(_) ->
         {C, ready} -> ok
     after 1000 ->
             throw(ready_msg_not_sent)
-    end.
+    end,
+
+    ?assertMatch({ok, #{server_name := _}}, nats:server_info(C)),
+    ?assertMatch({ok, #{family := _}}, nats:peername(C)),
+    ?assertMatch({ok, #{family := _}}, nats:sockname(C)),
+
+    ok.
 
 connect_fail_no_host(_) ->
     %% connect returns a new connection process,

--- a/test/nats_fake_server.erl
+++ b/test/nats_fake_server.erl
@@ -1,0 +1,185 @@
+%% Copyright 2024, Travelping GmbH <info@travelping.com>
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+%% this test suite is based on the test suite of nats_teacup (https://github.com/yuce/teacup_nats)
+
+-module(nats_fake_server).
+-behaviour(gen_server).
+
+%% API
+-export([start_link/0, start_link/1, port/1, send/3, close/2]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-define(SERVER, ?MODULE).
+
+-record(state, {owner, listen, accept, sockets = #{}}).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+start_link() ->
+    start_link(0).
+
+start_link(Port) ->
+    gen_server:start_link(?MODULE, [self(), Port], []).
+
+port(Server) ->
+    gen_server:call(Server, port).
+
+send(Server, Socket, Data) ->
+    gen_server:call(Server, {send, Socket, Data}).
+
+close(Server, Socket) ->
+    gen_server:call(Server, {close, Socket}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([Owner, Port]) ->
+    process_flag(trap_exit, true),
+    {ok, LSock} = socket:open(inet, stream, tcp),
+    ok = socket:setopt(LSock, {socket, reuseaddr}, true),
+    ok = socket:bind(LSock, #{family => inet, port => Port, addr => any}),
+    ok = socket:listen(LSock),
+
+    State = #state{owner = Owner, listen = LSock, accept = make_ref()},
+    select(LSock, State#state.accept),
+    ?LOG(debug, "Accepting on ~0p", [LSock]),
+
+    {ok, State}.
+
+handle_call(port, _From, #state{listen = LSock} = State) ->
+    {ok, #{port := Port}} = socket:sockname(LSock),
+    {reply, Port, State};
+
+handle_call({send, Socket, Data}, _From,  #state{sockets = Sockets} = State0)
+  when is_map_key(Socket, Sockets) ->
+    State =
+        case socket:send(Socket, Data, [], infinity) of
+            ok ->
+                State0;
+            {error, _} ->
+                close_socket(Socket, State0)
+        end,
+    {reply, ok, State};
+
+handle_call({close, Socket}, _From,  #state{sockets = Sockets} = State0)
+  when is_map_key(Socket, Sockets) ->
+    State = close_socket(Socket, State0),
+    {reply, ok, State};
+
+handle_call(_Request, _From, State) ->
+    Reply = {error, invalid_call},
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info({'$socket', LSock, select, SelectHandle} = _Info,
+            #state{listen = LSock, accept = SelectHandle} = State0) ->
+    ?LOG(debug, "Socket server Accept Info ~0p", [_Info]),
+    State = accept(State0),
+    {noreply, State};
+
+handle_info({'$socket', Socket, select, SelectHandle} = _Info,
+            #state{sockets = Sockets} = State0)
+  when is_map_key(Socket, Sockets) ->
+    ?LOG(debug, "Socket server Socket Info ~0p", [_Info]),
+    State =
+        case map_get(Socket, Sockets) of
+            #{select := SelectHandle} = SocketInfo0 ->
+                case read(Socket, SocketInfo0, State0) of
+                    {ok, SocketInfo} ->
+                        State0#state{sockets = Sockets#{Socket := SocketInfo}};
+                    {error, _} ->
+                        close_socket(Socket, State0)
+                end;
+            Other ->
+                ?LOG(error, "invalid select on ~0p: ~0p", [Socket, Other]),
+                State0
+        end,
+    {noreply, State};
+
+handle_info({'$socket', _Socket, abort, {_Handle, closed}} = _Info, State) ->
+    {noreply, State};
+
+handle_info(_Info, State) ->
+    ?LOG(error, "Socket server unknown Info ~0p", [_Info]),
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ?LOG(debug, "Socket server terminated with ~0p", [_Reason]),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+fmt_sockaddr(#{family := Family, port := Port, addr := Addr})
+  when is_tuple(Addr) ->
+    io_lib:format("~s: ~s:~w", [Family, inet:ntoa(Addr), Port]);
+fmt_sockaddr(#{family := Family, port := Port, addr := Addr})
+  when is_atom(Addr) ->
+    io_lib:format("~s: ~s:~w", [Family, Addr, Port]).
+
+select(Socket, Handle) ->
+    self() ! {'$socket', Socket, select, Handle}.
+
+accept(#state{owner = Owner, listen = LSock, accept = Handle, sockets = Sockets} = State0) ->
+    case socket:accept(LSock, Handle) of
+        {select, {select_info, accept, SelectHandle}} ->
+            ?LOG(debug, "Accept SelectHandle ~0p", [SelectHandle]),
+            State0#state{accept = SelectHandle};
+        {ok, Socket} ->
+            ?LOG(debug, "Accepted ~0p", [Socket]),
+            Owner ! {accepted, self(), Socket},
+            State = State0#state{sockets = Sockets#{Socket => init_socket(Socket)}},
+            accept(State)
+    end.
+
+init_socket(Socket) ->
+    {ok, SockAddr} = socket:peername(Socket),
+    ?LOG(debug, "accepted connection from ~s\n", [fmt_sockaddr(SockAddr)]),
+    Handle = make_ref(),
+    select(Socket, Handle),
+    #{peer => SockAddr, select => Handle}.
+
+read(Socket, #{select := Handle} = Info, #state{owner = Owner} = State) ->
+    case socket:recv(Socket, 0, [], Handle) of
+        {select, {select_info, recv, SelectHandle}} ->
+            ?LOG(debug, "recv select ~0p", [SelectHandle]),
+            {ok, Info#{select := SelectHandle}};
+        {ok, Data} ->
+            Owner ! {recv, self(), Socket, Data},
+            ?LOG(debug, "read data ~0p", [Data]),
+            read(Socket, Info, State);
+        {error, _} = Error ->
+            ?LOG(debug, "read error ~0p", [Error]),
+            Error
+    end.
+
+close_socket(Socket, #state{owner = Owner, sockets = Sockets} = State) ->
+    _ = socket:close(Socket),
+    Owner ! {closed, self(), Socket},
+    State#state{sockets = maps:remove(Socket, Sockets)}.


### PR DESCRIPTION
After a connection abort, try to reestablish subscriptions on that connections.

Servers are now passed as a list. That list can contain order and preference fields. The meaning of those fields follow RFC 3958, but the selection algorithm uses the pseudo code from 3GPP TS 29.303 Annex C.1.