### PR TITLE
use JS message metadata for switching from init to watching

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 
 {deps, [{opentelemetry_api, "1.4.0"},
-        {enats_msg, "1.0.2"}
+        {enats_msg, "1.0.3"}
        ]}.
 
 {minimum_otp_vsn, "27.0"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,11 +1,11 @@
 {"1.2.0",
-[{<<"enats_msg">>,{pkg,<<"enats_msg">>,<<"1.0.2">>},0},
+[{<<"enats_msg">>,{pkg,<<"enats_msg">>,<<"1.0.3">>},0},
  {<<"opentelemetry_api">>,{pkg,<<"opentelemetry_api">>,<<"1.4.0">>},0}]}.
 [
 {pkg_hash,[
- {<<"enats_msg">>, <<"685BE61385F917980493CC3C32F3A907399167F5508326FD9A1D783DD519235E">>},
+ {<<"enats_msg">>, <<"50631124F37D88BE76A91A5B96A6565C5981EBF917CD819F0175CA658A966F43">>},
  {<<"opentelemetry_api">>, <<"63CA1742F92F00059298F478048DFB826F4B20D49534493D6919A0DB39B6DB04">>}]},
 {pkg_hash_ext,[
- {<<"enats_msg">>, <<"4E412709D469E236BA2E38589D9C72209C0BA8D6B6BA1A40800C427F0E03BB8C">>},
+ {<<"enats_msg">>, <<"C4F2139E5144FABC99AFE01B8B016AD9DA278CDDC60857AC5D5AFB0AD1283534">>},
  {<<"opentelemetry_api">>, <<"3DFBBFAA2C2ED3121C5C483162836C4F9027DEF469C41578AF5EF32589FCFC58">>}]}
 ].


### PR DESCRIPTION
`num_pending` in the consumer create response can not be used to determin the number of initial messages to read. Only the `pending` metadata in the initial message can be used for that.